### PR TITLE
Avoid warning on GPIO5

### DIFF
--- a/sl32.yaml
+++ b/sl32.yaml
@@ -58,7 +58,9 @@ dashboard_import:
 uart:
   id: uart_dsmr
   baud_rate: 115200
-  rx_pin: GPIO5
+  rx_pin:
+    number: GPIO5
+    ignore_strapping_warning: true
   rx_buffer_size: 1700
   
 web_server:


### PR DESCRIPTION
We are fully aware that GPIO5 could be potentially used in a different way. In this case however, we are certain that this is desired behavior.