### PR TITLE
Adding params for peak usage (Belgium)

### DIFF
--- a/sl32.yaml
+++ b/sl32.yaml
@@ -151,6 +151,14 @@ sensor:
       name: "Gas Consumed"
     gas_delivered_be:
       name: "Gas Consumed Belgium"
+    active_energy_import_current_average_demand:
+      name: "Current Quarter-Hour Average Demand"
+      accuracy_decimals: 3
+    active_energy_import_maximum_demand_running_month:
+      name: "Maximum Demand Current Month"
+      accuracy_decimals: 3
+    active_energy_import_maximum_demand_last_13_months:
+      name: "Maximum Demand Last 13 Months"
   - platform: uptime
     name: "SlimmeLezer Uptime"
 

--- a/sl32.yaml
+++ b/sl32.yaml
@@ -152,7 +152,7 @@ sensor:
     gas_delivered_be:
       name: "Gas Consumed Belgium"
     active_energy_import_current_average_demand:
-      name: "Current Quarter-Hour Average Demand"
+      name: "Current Quarter/Hour Average Demand"
       accuracy_decimals: 3
     active_energy_import_maximum_demand_running_month:
       name: "Maximum Demand Current Month"

--- a/wt32.yaml
+++ b/wt32.yaml
@@ -160,6 +160,14 @@ sensor:
       name: "Gas Consumed"
     gas_delivered_be:
       name: "Gas Consumed Belgium"
+    active_energy_import_current_average_demand:
+      name: "Current Quarter-Hour Average Demand"
+      accuracy_decimals: 3
+    active_energy_import_maximum_demand_running_month:
+      name: "Maximum Demand Current Month"
+      accuracy_decimals: 3
+    active_energy_import_maximum_demand_last_13_months:
+      name: "Maximum Demand Last 13 Months"
   - platform: uptime
     name: "SlimmeLezer Uptime"
 

--- a/wt32.yaml
+++ b/wt32.yaml
@@ -161,7 +161,7 @@ sensor:
     gas_delivered_be:
       name: "Gas Consumed Belgium"
     active_energy_import_current_average_demand:
-      name: "Current Quarter-Hour Average Demand"
+      name: "Current Quarter/Hour Average Demand"
       accuracy_decimals: 3
     active_energy_import_maximum_demand_running_month:
       name: "Maximum Demand Current Month"


### PR DESCRIPTION
There are parameters for both 
- current highest demand (in a quarter or an hour)
- The maximum peak in a month
- The last 13 month peaks

This is interesting information in belgium, as the maximum peak is calculated in the price (last 12 months average).