### PR TITLE
Fix StringRef.copy() removed in ESPHome 2026.3.0

### DIFF
--- a/sl32.yaml
+++ b/sl32.yaml
@@ -16,7 +16,7 @@ esphome:
           then:
             - lambda: |-
                 std::string key(id(stored_decryption_key), 32);
-                id(dsmr_instance).set_decryption_key(key);
+                id(dsmr_instance).set_decryption_key(key.c_str());
           else:
             - logger.log:
                 level: info
@@ -48,8 +48,9 @@ api:
           value: !lambda "return private_key.length() == 32;"
       - lambda: |-
           if (private_key.length() == 32)
-            private_key.copy(id(stored_decryption_key), 32);
-          id(dsmr_instance).set_decryption_key(private_key);
+            if (private_key.length() == 32)
+            memcpy(id(stored_decryption_key), private_key.c_str(), 32);
+          id(dsmr_instance).set_decryption_key(private_key.c_str());
 
 ota:
   platform: esphome


### PR DESCRIPTION
ESPHome 2026.3.0 removed StringRef.copy(), breaking compilation.

Changes:
- on_boot: set_decryption_key(key) -> set_decryption_key(key.c_str())
- set_dsmr_key: private_key.copy() -> memcpy() with .c_str()
- set_dsmr_key: set_decryption_key(private_key) -> set_decryption_key(private_key.c_str())

Backward-compatible with older ESPHome versions.